### PR TITLE
Fix native modules building

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "ng lint",
     "start": "webpack --watch",
     "start:web": "webpack-dev-server --content-base . --port 4200 --inline",
-    "build:electron:main": "tsc main.ts --outDir dist && copyfiles package.json dist && cd dist && npm install --prod && cd ..",
+    "build:electron:main": "tsc main.ts --outDir dist && copyfiles package.json dist && cd dist && npm install --target=1.7.5 --arch=x64 --dist-url=https://atom.io/download/atom-shell --prod && cd ..",
     "build": "webpack --display-error-details && npm run build:electron:main",
     "build:prod": "cross-env NODE_ENV=production npm run build",
     "electron:serve": "npm run build:electron:main && electron ./dist --serve",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -197,7 +197,6 @@ module.exports = {
     "url": "require('url')",
     "util": "require('util')",
     "zlib": "require('zlib')",
-    "pcsclite": "require('bindings')('pcsclite')",
     "nfc-pcsc": "require('nfc-pcsc')"
   },
   "resolve": {


### PR DESCRIPTION
Hi @drajvver,

I have fixed (added) correct build params for Node Native Modules, so they are built against Electron instead of node (that it done in `build:electron:main` npm script, part of `electron:serve` – it is when all dependencies are installed again with --prod flag in dist directory).

### My changes
* Add build params for npm to `build:electron:main script`
* Remove unnecessary config from webpack externals

### How to make it work in your repo
1. Accept and merge this PR.
2. Sync changes to your local repo with `git pull`.
3. Remove the `dist` folder.
4. Run project as described in https://github.com/maximegris/angular-electron#to-build-for-development (e. g. `npm start` in one window and `npm run electron:serve` in another)

Let me know if it works. 🙂 

Hope it helps.
